### PR TITLE
The usage given by the CLI itself was technically wrong since it fail…

### DIFF
--- a/lib/sinatra-scaffolder/cli.rb
+++ b/lib/sinatra-scaffolder/cli.rb
@@ -3,7 +3,7 @@ require 'sinatra-scaffolder/create'
 
 module SinatraScaffolder
   class CLI < Thor
-    desc 'create', 'sets up all of the files and directories necessary for Sinatra development'
+    desc 'create [PROJECT_NAME]', 'sets up all of the files and directories necessary for Sinatra development'
     def create(project_name)
       SinatraScaffolder::Create.create project_name
     end


### PR DESCRIPTION
…s to demonstrate that you need a project name argument.
